### PR TITLE
Use original filename from enclosure when given

### DIFF
--- a/models/ZoteroImport/ImportProcess.php
+++ b/models/ZoteroImport/ImportProcess.php
@@ -343,8 +343,24 @@ class ZoteroImport_ImportProcess extends Omeka_Job_Process_AbstractProcess
         
         // Name the file.
         $uri = Zend_Uri::factory($urls['s3']);
-        // Set the original filename as the basename of the URL path.
-        $name = urldecode(basename($uri->getPath()));
+
+        // Set the original filename
+        $name = null;
+        $links = $element->link();
+        if ($links) {
+            foreach ($links as $link) {
+                $rel = $link->getAttribute('rel');
+                $title = $link->getAttribute('title');
+                if ($rel == 'enclosure' && $title) {
+                    $name = $title;
+                    break;
+                }
+            }
+        }
+
+        if (!$name) {
+            $name = urldecode(basename($uri->getPath()));
+        }
         
         // Set the file metadata.
         $this->_fileMetadata['files'][] = array(


### PR DESCRIPTION
Previously, all files came in with no extensions, practically requiring
you to disable extension validation to import files, and resulting in
files with no extension being saved.

This change uses the title attribute of the enclosure link to set the
original filename, if Zotero supplies it. Unfortunately, some
attachments (like snapshots) don't include the filename: for these, the
old system that simply uses the basename of the S3 URI is maintained.